### PR TITLE
remove unused imports

### DIFF
--- a/aip-console-tools-cli/src/test/java/com/castsoftware/aip/console/tools/TccCommandTest.java
+++ b/aip-console-tools-cli/src/test/java/com/castsoftware/aip/console/tools/TccCommandTest.java
@@ -1,30 +1,21 @@
 package com.castsoftware.aip.console.tools;
 
 import com.castsoftware.aip.console.tools.commands.BasicCallable;
-import com.castsoftware.aip.console.tools.commands.TccCommands.ComputeFunctionPoints;
-import com.castsoftware.aip.console.tools.commands.TccCommands.ComputeTransactions;
 import com.castsoftware.aip.console.tools.commands.TccCommands.TccCommand;
-import com.castsoftware.aip.console.tools.commands.TccCommands.UpdateSettings;
 import com.castsoftware.aip.console.tools.core.dto.ApiInfoDto;
 import com.castsoftware.aip.console.tools.core.dto.ApplicationCommonDetailsDto;
 import com.castsoftware.aip.console.tools.core.dto.ApplicationDto;
 import com.castsoftware.aip.console.tools.core.dto.jobs.JobExecutionDto;
 import com.castsoftware.aip.console.tools.core.dto.jobs.JobState;
 import com.castsoftware.aip.console.tools.core.dto.tcc.ComputeFunctionPointsProperties;
-import com.castsoftware.aip.console.tools.core.exceptions.ApiCallException;
-import com.castsoftware.aip.console.tools.core.services.ApplicationService;
 import com.castsoftware.aip.console.tools.core.services.ApplicationServiceImpl;
 import com.castsoftware.aip.console.tools.core.utils.ApiEndpointHelper;
 import com.castsoftware.aip.console.tools.core.utils.Constants;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.sun.org.apache.bcel.internal.Const;
-import org.checkerframework.checker.units.qual.A;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Spy;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -33,9 +24,6 @@ import picocli.CommandLine;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -49,8 +37,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 @RunWith(SpringRunner.class)

--- a/aip-console-tools-core/src/main/java/com/castsoftware/aip/console/tools/core/dto/tcc/RuleContentDto.java
+++ b/aip-console-tools-core/src/main/java/com/castsoftware/aip/console/tools/core/dto/tcc/RuleContentDto.java
@@ -3,7 +3,6 @@ package com.castsoftware.aip.console.tools.core.dto.tcc;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
 @AllArgsConstructor


### PR DESCRIPTION
unused imports are breaking build on jenkins, therefore removed unused imports so the build works properly